### PR TITLE
Census segmentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ ruby RUBY_VERSION
 DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim.git", branch: "release/0.26-stable" }.freeze
 
 gem "decidim", DECIDIM_VERSION
+gem "decidim-age_and_district_action_authorization", git: "https://github.com/CodiTramuntana/decidim-module-age_and_district_action_authorization"
 gem "decidim-conferences", DECIDIM_VERSION
 gem "decidim-consultations", DECIDIM_VERSION
 gem "decidim-file_authorization_handler", git: "https://github.com/CodiTramuntana/decidim-file_authorization_handler.git", tag: "v0.26.2.5"
-gem "decidim-age_and_district_action_authorization", git: "https://github.com/CodiTramuntana/decidim-module-age_and_district_action_authorization"
 gem "decidim-term_customizer", git: "https://github.com/mainio/decidim-module-term_customizer.git", branch: "release/0.26-stable"
 gem "decidim-verifications-members_picker", git: "https://github.com/gencat/decidim-verifications-members_picker.git", tag: "0.0.2"
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,8 @@ DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim.git", branch
 gem "decidim", DECIDIM_VERSION
 gem "decidim-conferences", DECIDIM_VERSION
 gem "decidim-consultations", DECIDIM_VERSION
-# gem "decidim-file_authorization_handler", git: "https://github.com/CodiTramuntana/decidim-file_authorization_handler.git", tag: "v0.26.2.4"
+gem "decidim-file_authorization_handler", git: "https://github.com/CodiTramuntana/decidim-file_authorization_handler.git", tag: "v0.26.2.5"
 gem "decidim-age_and_district_action_authorization", git: "https://github.com/CodiTramuntana/decidim-module-age_and_district_action_authorization"
-gem "decidim-file_authorization_handler", path: "/home/oliver/prog/decidim/modules/decidim-file_authorization_handler-codit"
 gem "decidim-term_customizer", git: "https://github.com/mainio/decidim-module-term_customizer.git", branch: "release/0.26-stable"
 gem "decidim-verifications-members_picker", git: "https://github.com/gencat/decidim-verifications-members_picker.git", tag: "0.0.2"
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,9 @@ DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim.git", branch
 gem "decidim", DECIDIM_VERSION
 gem "decidim-conferences", DECIDIM_VERSION
 gem "decidim-consultations", DECIDIM_VERSION
-gem "decidim-file_authorization_handler", git: "https://github.com/CodiTramuntana/decidim-file_authorization_handler.git", tag: "v0.26.2.4"
+# gem "decidim-file_authorization_handler", git: "https://github.com/CodiTramuntana/decidim-file_authorization_handler.git", tag: "v0.26.2.4"
+gem "decidim-age_and_district_action_authorization", git: "https://github.com/CodiTramuntana/decidim-module-age_and_district_action_authorization"
+gem "decidim-file_authorization_handler", path: "/home/oliver/prog/decidim/modules/decidim-file_authorization_handler-codit"
 gem "decidim-term_customizer", git: "https://github.com/mainio/decidim-module-term_customizer.git", branch: "release/0.26-stable"
 gem "decidim-verifications-members_picker", git: "https://github.com/gencat/decidim-verifications-members_picker.git", tag: "0.0.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/CodiTramuntana/decidim-file_authorization_handler.git
+  revision: 66adaf43ee09aedb8966a7efaf575ef83846ef51
+  tag: v0.26.2.5
+  specs:
+    decidim-file_authorization_handler (0.26.2.5)
+      decidim (~> 0.26.2)
+      decidim-admin (~> 0.26.2)
+      rails (>= 5.2)
+
+GIT
   remote: https://github.com/CodiTramuntana/decidim-module-age_and_district_action_authorization
   revision: 9fdd678c143f72bc271651ce6d50c929f20afc88
   specs:
@@ -205,14 +215,6 @@ GIT
     decidim-term_customizer (0.26.0)
       decidim-admin (~> 0.26.0)
       decidim-core (~> 0.26.0)
-
-PATH
-  remote: /home/oliver/prog/decidim/modules/decidim-file_authorization_handler-codit
-  specs:
-    decidim-file_authorization_handler (0.26.2.5)
-      decidim (~> 0.26.2)
-      decidim-admin (~> 0.26.2)
-      rails (>= 5.2)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,9 @@
 GIT
-  remote: https://github.com/CodiTramuntana/decidim-file_authorization_handler.git
-  revision: c9c6aa5af910c04e3d4f2767eff582319a286eec
-  tag: v0.26.2.4
+  remote: https://github.com/CodiTramuntana/decidim-module-age_and_district_action_authorization
+  revision: 9fdd678c143f72bc271651ce6d50c929f20afc88
   specs:
-    decidim-file_authorization_handler (0.26.2.4)
-      decidim (~> 0.26.2)
-      decidim-admin (~> 0.26.2)
-      rails (>= 5.2)
+    decidim-age_and_district_action_authorization (0.0.1)
+      decidim (>= 0.24.0)
 
 GIT
   remote: https://github.com/CodiTramuntana/decidim.git
@@ -208,6 +205,14 @@ GIT
     decidim-term_customizer (0.26.0)
       decidim-admin (~> 0.26.0)
       decidim-core (~> 0.26.0)
+
+PATH
+  remote: /home/oliver/prog/decidim/modules/decidim-file_authorization_handler-codit
+  specs:
+    decidim-file_authorization_handler (0.26.2.5)
+      decidim (~> 0.26.2)
+      decidim-admin (~> 0.26.2)
+      rails (>= 5.2)
 
 GEM
   remote: https://rubygems.org/
@@ -811,6 +816,7 @@ DEPENDENCIES
   byebug
   daemons
   decidim!
+  decidim-age_and_district_action_authorization!
   decidim-conferences!
   decidim-consultations!
   decidim-dev!

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -23,3 +23,13 @@ Decidim.register_assets_path File.expand_path("app/packs", Rails.application.roo
 
 Rails.application.config.i18n.available_locales = Decidim.available_locales
 Rails.application.config.i18n.default_locale = Decidim.default_locale
+
+Rails.application.config.after_initialize do
+  workflow= Decidim::Verifications.find_workflow_manifest("file_authorization_handler")
+  workflow.action_authorizer = "Decidim::AgeAndDistrictActionAuthorization::Authorizer"
+  workflow.options do |options|
+    options.attribute :min_age, type: :string, required: false
+    options.attribute :max_age, type: :string, required: false
+    options.attribute :allowed_districts, type: :string, required: false
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,10 @@
 
 en:
   hello: "Hello world"
+  decidim:
+    authorization_handlers:
+      file_authorization_handler:
+        fields:
+          allowed_districts: Allowed districts
+          min_age: Minimum age
+          max_age: Maximum age

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,8 @@
+es:
+  decidim:
+    authorization_handlers:
+      file_authorization_handler:
+        fields:
+          allowed_districts: Distritos permitidos
+          min_age: Edad mínima
+          max_age: Edad máxima

--- a/db/migrate/20221209115141_add_extras_to_census_datum.decidim_file_authorization_handler.rb
+++ b/db/migrate/20221209115141_add_extras_to_census_datum.decidim_file_authorization_handler.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_file_authorization_handler (originally 20221207143742)
+
+class AddExtrasToCensusDatum < ActiveRecord::Migration[6.0]
+  def change
+    add_column :decidim_file_authorization_handler_census_data, :extras, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_13_111929) do
+ActiveRecord::Schema.define(version: 2022_12_09_115141) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -767,6 +767,7 @@ ActiveRecord::Schema.define(version: 2022_07_13_111929) do
     t.string "id_document"
     t.date "birthdate"
     t.datetime "created_at", null: false
+    t.jsonb "extras"
     t.index ["decidim_organization_id"], name: "decidim_census_data_org_id_index"
   end
 


### PR DESCRIPTION
This PR adds census segmentation by age and by district.

This feature is based in two dependencies:

- https://github.com/CodiTramuntana/decidim-file_authorization_handler/pull/7 supporting new extras field.
- https://github.com/CodiTramuntana/decidim-module-age_and_district_action_authorization

To make both modules work together the census must have an extra `district` column. It is important that the header of the  column is set exactly as `district`.