### PR TITLE
Do not override omniauth secrets for :production env

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -89,16 +89,3 @@ production:
   smtp_port: <%= ENV["MAILER_SMTP_PORT"] || "587" %>
   smtp_starttls_auto: false
   smtp_authentication: "login"
-  omniauth:
-    facebook:
-      enabled: false
-      app_id: <%= ENV["OMNIAUTH_FACEBOOK_APP_ID"] %>
-      app_secret: <%= ENV["OMNIAUTH_FACEBOOK_APP_SECRET"] %>
-    twitter:
-      enabled: false
-      api_key: <%= ENV["OMNIAUTH_TWITTER_API_KEY"] %>
-      api_secret: <%= ENV["OMNIAUTH_TWITTER_API_SECRET"] %>
-    google_oauth2:
-      enabled: false
-      client_id: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_ID"] %>
-      client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>


### PR DESCRIPTION
There was a bad override for omniauth providers in the production secrets block.

This PR removes the omniauth override from the production env secrets as the `default` is already good.