### PR TITLE
Increase smtp timeouts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,9 @@ Rails.application.configure do
     password: Rails.application.secrets.smtp_password,
     domain: Rails.application.secrets.smtp_domain,
     enable_starttls_auto: Rails.application.secrets.smtp_starttls_auto,
-    openssl_verify_mode: "none"
+    openssl_verify_mode: "none",
+    open_timeout: 30,
+    read_timeout: 30
   }
 
   if Rails.application.secrets.sendgrid


### PR DESCRIPTION
Because of the used SMTP server slowness we have to increase our client's timeouts.